### PR TITLE
Refactor: 공통 코드 관리 방법 수정

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 ### IntelliJ IDEA ###
 .idea
 k8s/environments/secrets/secret.yaml
+k8s/environments/configmaps/configmap.yaml
+k8s/applications/apigateway/ingress/ingress.yaml

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 ### IntelliJ IDEA ###
 .idea
+gradle.properties
 k8s/environments/secrets/secret.yaml
 k8s/environments/configmaps/configmap.yaml
 k8s/applications/apigateway/ingress/ingress.yaml

--- a/apigateway-service/build.gradle
+++ b/apigateway-service/build.gradle
@@ -21,13 +21,6 @@ configurations {
 
 repositories {
     mavenCentral()
-    maven {
-        url = uri("https://maven.pkg.github.com/Song-s-PaaSTA/plog-maven-repo")
-        credentials {
-            username = project.findProperty("MAVEN_USER") ?: ""
-            password = project.findProperty("MAVEN_PASSWORD") ?: ""
-        }
-    }
 }
 
 ext {
@@ -35,29 +28,27 @@ ext {
 }
 
 dependencies {
-    implementation 'org.springframework.boot:spring-boot-starter-actuator'
-    implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'org.springframework.boot:spring-boot-starter-webflux'
     implementation 'org.springframework.cloud:spring-cloud-starter-gateway'
     implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
-    implementation 'org.springframework.boot:spring-boot-starter-webflux'
 
-    developmentOnly 'org.springframework.boot:spring-boot-devtools'
-    testImplementation 'org.springframework.boot:spring-boot-starter-test'
-    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
-
-    implementation 'com.songspasssta:common:0.0.1-SNAPSHOT'
-
-    compileOnly 'org.projectlombok:lombok'
-    annotationProcessor 'org.projectlombok:lombok'
-
-    testImplementation 'org.springframework.security:spring-security-test'
     implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation 'org.springframework.security:spring-security-config'
 
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springdoc:springdoc-openapi-starter-webflux-ui:2.6.0'
 
     implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
     implementation 'io.jsonwebtoken:jjwt-impl:0.11.5'
     implementation 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+
+    developmentOnly 'org.springframework.boot:spring-boot-devtools'
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'org.springframework.security:spring-security-test'
+
+    compileOnly 'org.projectlombok:lombok'
+    annotationProcessor 'org.projectlombok:lombok'
 }
 
 dependencyManagement {

--- a/apigateway-service/build.gradle
+++ b/apigateway-service/build.gradle
@@ -21,6 +21,13 @@ configurations {
 
 repositories {
     mavenCentral()
+    maven {
+        url = uri("https://maven.pkg.github.com/Song-s-PaaSTA/plog-maven-repo")
+        credentials {
+            username = project.findProperty("MAVEN_USER") ?: ""
+            password = project.findProperty("MAVEN_PASSWORD") ?: ""
+        }
+    }
 }
 
 ext {
@@ -38,7 +45,7 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
-    implementation files('../common/build/libs/common-0.0.1-SNAPSHOT-plain.jar')
+    implementation 'com.songspasssta:common:0.0.1-SNAPSHOT'
 
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'

--- a/common/.gitignore
+++ b/common/.gitignore
@@ -6,6 +6,7 @@ build/libs
 build/reports
 build/test-results
 build/tmp
+build/publications
 build/resolvedMainClassName
 !gradle/wrapper/gradle-wrapper.jar
 !**/src/main/**/build/

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -1,7 +1,8 @@
 plugins {
-	id 'java'
+	id 'java-library' // include java plugin
 	id 'org.springframework.boot' version '3.3.3'
 	id 'io.spring.dependency-management' version '1.1.6'
+	id 'maven-publish'
 }
 
 group = 'com.songspasssta'
@@ -30,7 +31,8 @@ ext {
 
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter'
-	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+	api 'org.springframework.boot:spring-boot-starter-data-jpa'
+	compileOnly 'jakarta.persistence:jakarta.persistence-api'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	compileOnly 'org.projectlombok:lombok'
@@ -43,6 +45,27 @@ dependencies {
 	annotationProcessor "com.querydsl:querydsl-apt:${querydslVersion}:jakarta"
 	annotationProcessor "jakarta.annotation:jakarta.annotation-api"
 	annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+}
+
+publishing {
+	publications {
+		mavenJava(MavenPublication) {
+			from components.java
+			groupId = 'com.songspasssta'
+			artifactId = 'common'
+			version = '0.0.1-SNAPSHOT'
+		}
+	}
+	repositories {
+		maven {
+			name = "GitHubPackages"
+			url = uri("https://maven.pkg.github.com/Song-s-PaaSTA/plog-maven-repo")
+			credentials {
+				username = project.findProperty("MAVEN_USER") ?: ""
+				password = project.findProperty("MAVEN_PASSWORD") ?: ""
+			}
+		}
+	}
 }
 
 dependencyManagement {

--- a/member-service/build.gradle
+++ b/member-service/build.gradle
@@ -21,6 +21,13 @@ configurations {
 
 repositories {
     mavenCentral()
+    maven {
+        url = uri("https://maven.pkg.github.com/Song-s-PaaSTA/plog-maven-repo")
+        credentials {
+            username = project.findProperty("MAVEN_USER") ?: ""
+            password = project.findProperty("MAVEN_PASSWORD") ?: ""
+        }
+    }
 }
 
 ext {
@@ -45,7 +52,7 @@ dependencies {
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
 
-    implementation files('../common/build/libs/common-0.0.1-SNAPSHOT-plain.jar')
+    implementation 'com.songspasssta:common:0.0.1-SNAPSHOT'
 
     testImplementation 'org.springframework.security:spring-security-test'
     implementation 'org.springframework.boot:spring-boot-starter-security'

--- a/plogging-service/build.gradle
+++ b/plogging-service/build.gradle
@@ -21,6 +21,13 @@ configurations {
 
 repositories {
 	mavenCentral()
+	maven {
+		url = uri("https://maven.pkg.github.com/Song-s-PaaSTA/plog-maven-repo")
+		credentials {
+			username = project.findProperty("MAVEN_USER") ?: ""
+			password = project.findProperty("MAVEN_PASSWORD") ?: ""
+		}
+	}
 }
 
 ext {
@@ -42,7 +49,7 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
-	implementation files('../common/build/libs/common-0.0.1-SNAPSHOT-plain.jar')
+	implementation 'com.songspasssta:common:0.0.1-SNAPSHOT'
 
 	testImplementation 'org.springframework.security:spring-security-test'
 	implementation 'org.springframework.boot:spring-boot-starter-security'

--- a/report-service/build.gradle
+++ b/report-service/build.gradle
@@ -21,6 +21,13 @@ configurations {
 
 repositories {
 	mavenCentral()
+	maven {
+		url = uri("https://maven.pkg.github.com/Song-s-PaaSTA/plog-maven-repo")
+		credentials {
+			username = project.findProperty("MAVEN_USER") ?: ""
+			password = project.findProperty("MAVEN_PASSWORD") ?: ""
+		}
+	}
 }
 
 ext {
@@ -41,7 +48,7 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
-	implementation files('../common/build/libs/common-0.0.1-SNAPSHOT-plain.jar')
+	implementation 'com.songspasssta:common:0.0.1-SNAPSHOT'
 
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.6.0'
 

--- a/trash-service/.gitignore
+++ b/trash-service/.gitignore
@@ -38,3 +38,4 @@ out/
 
 ### application*.yml ###
 src/main/resources/*.yml
+src/main/resources/*.sql

--- a/trash-service/build.gradle
+++ b/trash-service/build.gradle
@@ -21,14 +21,6 @@ configurations {
 
 repositories {
 	mavenCentral()
-}
-
-ext {
-	set('springCloudVersion', "2023.0.3")
-}
-
-repositories {
-	mavenCentral()
 	maven {
 		url = uri("https://maven.pkg.github.com/Song-s-PaaSTA/plog-maven-repo")
 		credentials {
@@ -36,6 +28,10 @@ repositories {
 			password = project.findProperty("MAVEN_PASSWORD") ?: ""
 		}
 	}
+}
+
+ext {
+	set('springCloudVersion', "2023.0.3")
 }
 
 dependencies {

--- a/trash-service/build.gradle
+++ b/trash-service/build.gradle
@@ -27,13 +27,24 @@ ext {
 	set('springCloudVersion', "2023.0.3")
 }
 
+repositories {
+	mavenCentral()
+	maven {
+		url = uri("https://maven.pkg.github.com/Song-s-PaaSTA/plog-maven-repo")
+		credentials {
+			username = project.findProperty("MAVEN_USER") ?: ""
+			password = project.findProperty("MAVEN_PASSWORD") ?: ""
+		}
+	}
+}
+
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
-  implementation 'org.springframework.boot:spring-boot-starter-actuator'
-  compileOnly 'org.projectlombok:lombok'
+  	implementation 'org.springframework.boot:spring-boot-starter-actuator'
+  	compileOnly 'org.projectlombok:lombok'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 
 	runtimeOnly 'org.postgresql:postgresql'
@@ -41,7 +52,7 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
-	implementation files('../common/build/libs/common-0.0.1-SNAPSHOT-plain.jar')
+	implementation 'com.songspasssta:common:0.0.1-SNAPSHOT'
 
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.6.0'
 }


### PR DESCRIPTION
## Summary

- 공통 코드 관리 방법 수정

## Issue

> #7 

## Description

### 현재 공통 코드 관리
```
implementation files('../common/build/libs/common-0.0.1-SNAPSHOT-plain.jar')
```

- Common 모듈에 공통으로 사용하는 코드를 작성
    
    → Common에 기능 하나가 변경되면 모든 모듈에 영향이 발생 (의존성이 강함)
    

### 리팩토링 방법

- Github Maven Registry: GitHub에서 제공하는 Maven 저장소, 최근에는 Nexus 대신 사용
    - 루트도메인/오거나이제이션(조직)/GitHub 저장소 이름
    - https://maven.pkg.github.com/Song-s-PaaSTA/plog-maven-repo
    - 따라서 실제 존재하는 저장소 필요
- gradle.properties (레포지토리 바로 안에 넣기)
    - 파일은 노션에 있음

### Common 모듈 수정

- build.gradle

```
plugins {
		id 'java-library' // include java plugin
		id 'org.springframework.boot' version '3.3.3'
		id 'io.spring.dependency-management' version '1.1.6'
		id 'maven-publish'
}
```

- api: 다른 모듈에서 common을 의존할 때 이 의존성도 함께 전달(전이)됨. 공통 엔티티/도메인 제공에 적합
- compileOnly: 컴파일 시에만 필요. JAR에는 포함 안 됨. 어노테이션/인터페이스 등 런타임에 이미 구현체가 제공될 때 사용

```
dependencies {
		implementation 'org.springframework.boot:spring-boot-starter'
		api 'org.springframework.boot:spring-boot-starter-data-jpa'
		compileOnly 'jakarta.persistence:jakarta.persistence-api'
}
```

```
publishing {
	publications {
		mavenJava(MavenPublication) {
			from components.java
			groupId = 'com.songspasssta'
			artifactId = 'common'
			version = '0.0.1-SNAPSHOT'
		}
	}
	repositories {
		maven {
			name = "GitHubPackages"
			url = uri("https://maven.pkg.github.com/Song-s-PaaSTA/plog-maven-repo")
			credentials {
				username = project.findProperty("MAVEN_USER") ?: ""
				password = project.findProperty("MAVEN_PASSWORD") ?: ""
			}
		}
	}
}
```

- 빌드하면 올라감

```
./gradlew publish
```

![image](https://github.com/user-attachments/assets/c8da1ae1-52e1-484c-8d7d-4501e5de932a)

### 각 서비스 수정

- build.gradle (apigateway 제외)

```
repositories {
    mavenCentral()
    maven {
        url = uri("https://maven.pkg.github.com/Song-s-PaaSTA/plog-maven-repo")
        credentials {
            username = project.findProperty("MAVEN_USER") ?: ""
            password = project.findProperty("MAVEN_PASSWORD") ?: ""
        }
    }
}
```

```
dependencies {
		implementation 'com.songspasssta:common:0.0.1-SNAPSHOT'
}
```

### 트러블슈팅

- common 모듈의 spring-boot-starter-web 의존성이 API Gateway 서비스로 전이되면서 WebFlux 구성과 충돌이 발생함 → API Gateway에서 common 의존성 삭제
- API Gateway에서는 라우팅에 집중해서 보통 common 모듈을 사용하지 않거나 최소한으로 사용
- common의 build.gradle

```
implementation 'org.springframework.boot:spring-boot-starter-web'
```